### PR TITLE
Add multi[ple]-os multi select mode

### DIFF
--- a/src/scripts/directives/selection-model.js
+++ b/src/scripts/directives/selection-model.js
@@ -334,7 +334,7 @@ angular.module('selectionModel').directive('selectionModel', [
           }
 
           // Toggle row if only one item is selected
-          if (isModeOs && smItem[selectedAttribute] && selectedItemsList.length == 1) {
+          if (isModeOs && smItem[selectedAttribute] && selectedItemsList.length === 1) {
             smItem[selectedAttribute] = false;
             scope.$apply();
             return;


### PR DESCRIPTION
Modeled after the TableTools "os" row selection option for the DataTables library. 

multi[ple]-os will toggle selection if there is only one item selected.
multi[ple]-os will act as if ctrl were held when shift-selecting multiple rows.

The example provided by TableTools on DataTables.net:
http://www.datatables.net/release-datatables/extensions/TableTools/examples/select_os.html