### PR TITLE
Enable selection handler property to be populated via selection-model-handle-events attribute

### DIFF
--- a/src/scripts/directives/selection-model.js
+++ b/src/scripts/directives/selection-model.js
@@ -23,6 +23,7 @@ angular.module('selectionModel').directive('selectionModel', [
         var defaultOptions = selectionModelOptions.get()
           , defaultSelectedAttribute = defaultOptions.selectedAttribute
           , defaultSelectedClass = defaultOptions.selectedClass
+          , defaultHandleEvents = defaultOptions.handleEvents
           , defaultType = defaultOptions.type
           , defaultMode = defaultOptions.mode
           , defaultCleanupStrategy = defaultOptions.cleanupStrategy;
@@ -73,7 +74,17 @@ angular.module('selectionModel').directive('selectionModel', [
          * default class name.
          */
         var selectedClass = scope.$eval(attrs.selectionModelSelectedClass) || defaultSelectedClass;
-
+        
+        /**
+         * The selection handler events
+         *
+         * When to handle the selection. By default the selection is executed
+         * only on 'click' event. Other methods can be registered by specifying
+         * them on the selection-model-handle-events attribute. Multiple events
+         * can be registered comma separated.
+         */
+        var handleEvents = scope.$eval(attrs.selectionModelHandleEvents) || defaultHandleEvents;
+        
         /**
          * The cleanup strategy
          *
@@ -363,7 +374,7 @@ angular.module('selectionModel').directive('selectionModel', [
           }
         };
 
-        element.on('click', handleClick);
+        element.on(handleEvents, handleClick);
         if('checkbox' === smType) {
           var elCb = element.find('input');
           if(elCb[0] && 'checkbox' === elCb[0].type) {

--- a/src/scripts/services/selection-model-options.js
+++ b/src/scripts/services/selection-model-options.js
@@ -15,7 +15,8 @@ angular.module('selectionModel').provider('selectionModelOptions', [function() {
     selectedClass: 'selected',
     type: 'basic',
     mode: 'single',
-    cleanupStrategy: 'none'
+    cleanupStrategy: 'none',
+    handleEvents: 'click'
   };
 
   this.set = function(userOpts) {


### PR DESCRIPTION
**Description:**

We need this update in order to trigger selection on different events.
With this change you can specify them in the 'selection-model-handle-events' attribute.
It is evaluated by the selectionModel directive.

**Example:**

`<li data-ng-repeat="child in parent" data-selection-model data-selection-model-handle-events="'click mousedown'" ></li>`

**Notes:**
The attribute value is evaluated by the directive, so you need to specify it in single quotes for strings or provide a getter function.